### PR TITLE
Support larger site Headers for apisix nginx

### DIFF
--- a/apisix/error_values/httpStart
+++ b/apisix/error_values/httpStart
@@ -1,3 +1,9 @@
+client_header_buffer_size 4m;
+large_client_header_buffers 8 4m;
+proxy_buffer_size 256k;
+proxy_buffers 4 512k;
+proxy_busy_buffers_size 512k;
+
 more_clear_headers Server;
 
 map $status $status_text {


### PR DESCRIPTION
Sites like github.com use return Headers that are over 4k which is the default limit for nginx.