### PR TITLE
feat: Support custom keyloak themes

### DIFF
--- a/ewc/dev-portal-init/main.tf
+++ b/ewc/dev-portal-init/main.tf
@@ -284,7 +284,7 @@ resource "helm_release" "dev-portal" {
     },
     {
       name  = "frontend.image.tag"
-      value = "sha-a13cd70"
+      value = "sha-03e5536"
     },
     {
       name  = "frontend.keycloak_logout_url"

--- a/ewc/dev-portal-init/main.tf
+++ b/ewc/dev-portal-init/main.tf
@@ -155,7 +155,7 @@ resource "helm_release" "keycloak" {
       repository                   = "quay.io/keycloak/keycloak"
       tag                          = "26.4.5"
       kc_custom_theme_image        = "ghcr.io/eumetnet/dev-portal/keycloak-theme"
-      kc_custom_theme_tag          = "sha-6ecf567"
+      kc_custom_theme_tag          = "sha-df9b0f4"
     })
   ]
 }

--- a/ewc/dev-portal-init/main.tf
+++ b/ewc/dev-portal-init/main.tf
@@ -154,6 +154,8 @@ resource "helm_release" "keycloak" {
       ip                           = var.load_balancer_ip
       repository                   = "quay.io/keycloak/keycloak"
       tag                          = "26.4.5"
+      kc_custom_theme_image        = "ghcr.io/eumetnet/dev-portal/keycloak-theme"
+      kc_custom_theme_tag          = "sha-6ecf567"
     })
   ]
 }

--- a/ewc/templates/helm-values/keycloak-values-template.yaml
+++ b/ewc/templates/helm-values/keycloak-values-template.yaml
@@ -62,11 +62,33 @@ proxy:
 #livenessProbe: '{"httpGet":{"path":"/health/live","port":"http-internal","scheme":"HTTP"},"initialDelaySeconds":40,"timeoutSeconds":5,"periodSeconds":10}'
 #readinessProbe: '{"httpGet":{"path":"/health/ready","port":"http-internal","scheme":"HTTP"},"initialDelaySeconds":40,"timeoutSeconds":2,"periodSeconds":10}'
 #startupProbe: '{"httpGet":{"path":"/health/ready","port":"http-internal","scheme":"HTTP"},"initialDelaySeconds":30,"timeoutSeconds":5,"failureThreshold":60,"periodSeconds":5}'
+extraInitContainers: |
+  - name: custom-keycloak-theme-provider
+    image: ${kc_custom_theme_image}:${kc_custom_theme_tag}
+    imagePullPolicy: IfNotPresent
+    command:
+      - sh
+    args:
+      - -c
+      - |
+        cp -R /theme/* /themes/
+    volumeMounts:
+      - name: themes
+        mountPath: /themes
+    resources:
+      requests:
+        cpu: "50m"
+        memory: "256Mi"
+      limits:
+        cpu: "50m"
+        memory: "256Mi"
 
 extraVolumeMounts: |
   - name: config
     mountPath: /opt/keycloak/data/import
     readOnly: true
+  - name: themes
+    mountPath: /opt/keycloak/themes/
 
 extraVolumes: |
   - name: config
@@ -75,6 +97,8 @@ extraVolumes: |
       items:
         - key: realm.json
           path: realm.json
+  - name: themes
+    emptyDir: {}
 
 ingress:
   enabled: true

--- a/ewc/templates/helm-values/keycloak-values-template.yaml
+++ b/ewc/templates/helm-values/keycloak-values-template.yaml
@@ -71,6 +71,7 @@ extraInitContainers: |
     args:
       - -c
       - |
+        cp -R /opt/keycloak/themes/* /themes/ 2>/dev/null || true
         cp -R /theme/* /themes/
     volumeMounts:
       - name: themes
@@ -88,7 +89,7 @@ extraVolumeMounts: |
     mountPath: /opt/keycloak/data/import
     readOnly: true
   - name: themes
-    mountPath: /opt/keycloak/themes/gdpr-theme
+    mountPath: /opt/keycloak/themes/
 
 extraVolumes: |
   - name: config

--- a/ewc/templates/helm-values/keycloak-values-template.yaml
+++ b/ewc/templates/helm-values/keycloak-values-template.yaml
@@ -88,7 +88,7 @@ extraVolumeMounts: |
     mountPath: /opt/keycloak/data/import
     readOnly: true
   - name: themes
-    mountPath: /opt/keycloak/themes/
+    mountPath: /opt/keycloak/themes/gdpr-theme
 
 extraVolumes: |
   - name: config

--- a/ewc/templates/helm-values/keycloak-values-template.yaml
+++ b/ewc/templates/helm-values/keycloak-values-template.yaml
@@ -71,8 +71,7 @@ extraInitContainers: |
     args:
       - -c
       - |
-        cp -R /opt/keycloak/themes/* /themes/ 2>/dev/null || true
-        cp -R /theme/* /themes/
+        cp -R /theme/gdpr-theme /themes/
     volumeMounts:
       - name: themes
         mountPath: /themes
@@ -89,7 +88,8 @@ extraVolumeMounts: |
     mountPath: /opt/keycloak/data/import
     readOnly: true
   - name: themes
-    mountPath: /opt/keycloak/themes/
+    mountPath: /opt/keycloak/themes/gdpr-theme
+    subPath: gdpr-theme
 
 extraVolumes: |
   - name: config

--- a/ewc/templates/helm-values/keycloak-values-template.yaml
+++ b/ewc/templates/helm-values/keycloak-values-template.yaml
@@ -71,7 +71,7 @@ extraInitContainers: |
     args:
       - -c
       - |
-        cp -R /theme/gdpr-theme /themes/
+        cp -R /theme/* /themes/
     volumeMounts:
       - name: themes
         mountPath: /themes
@@ -88,8 +88,7 @@ extraVolumeMounts: |
     mountPath: /opt/keycloak/data/import
     readOnly: true
   - name: themes
-    mountPath: /opt/keycloak/themes/gdpr-theme
-    subPath: gdpr-theme
+    mountPath: /opt/keycloak/themes/
 
 extraVolumes: |
   - name: config


### PR DESCRIPTION
Add a possibility to load custom keycloak themes with a _sidecar pattern_ via `initContainer`

The themes and the provider container are both developed in the [dev portal](https://github.com/EUMETNET/Dev-portal) repo.

