### PR TITLE
Increase prometheus log retention to 45d

### DIFF
--- a/ewc/monitoring.tf
+++ b/ewc/monitoring.tf
@@ -66,6 +66,9 @@ grafana:
   grafana.ini:
     security:
       angular_support_enabled: true
+prometheus:
+  prometheusSpec:
+    retention: 45d
 alertmanager:
   alertmanagerSpec:
     alertmanagerConfigMatcherStrategy:


### PR DESCRIPTION
# Increased log retention
We are required to provide metrics from the system on a quarterly basis, Grafana is the preferred tool but at the moment log retention time is not suitable for that purpose. More information STU-29858 in JIRA.

## Refactors
- Increase `prometheus` log retention to `45d`